### PR TITLE
Fix #2, Build Warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ all:
 	gcc $(INCLUDE_PATH) -g -o cfe_ts_crc cfe_ts_crc.c
 
 clean:
-	rm cfe_ts_crc
+	rm -f cfe_ts_crc
 


### PR DESCRIPTION
include stdlib.h was fixed by pull request "Table CRC Tool Fails To Close File Descriptor, # 1"
