### PR TITLE
Close #4 and #21, add version.h and include buildnumber and baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This lab application is a ground utility to generate binary table CRCs for cFS. 
 
 ## Version Notes
 
+### Development Build: 1.1.0+dev7
+
+- Create a version header file
+- Report version when responding to `-help` command
+- See <https://github.com/nasa/tblCRCTool/pull/22>
+
 ### Development Build: 1.1.1
 
 - Apply Code Style
@@ -31,4 +37,3 @@ This ground utility was developed for a specific mission/configuration, and may 
 For best results, submit issues:questions or issues:help wanted requests at https://github.com/nasa/cFS.
 
 Official cFS page: http://cfs.gsfc.nasa.gov
-

--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -45,6 +45,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "cfe_ts_crc_version.h"
+
 #define CFE_ES_CRC_8       1 /**< \brief CRC ( 8 bit additive - returns 32 bit total) (Currently not implemented) */
 #define CFE_ES_CRC_16      2 /**< \brief CRC (16 bit additive - returns 32 bit total) */
 #define CFE_ES_CRC_32      3 /**< \brief CRC (32 bit additive - returns 32 bit total) (Currently not implemented) */
@@ -135,7 +137,7 @@ int main(int argc, char **argv)
     /* check for valid input */
     if ((argc != 2) || (strncmp(argv[1], "-help", 100) == 0))
     {
-        printf("\ncFE TS CRC calculator for LRO files.");
+        printf("%s\n", CFE_TS_CRC_VERSION_STRING);
         printf("\nUsage: cfe_ts_crc [filename]\n");
         exit(0);
     }

--- a/cfe_ts_crc_version.h
+++ b/cfe_ts_crc_version.h
@@ -1,0 +1,69 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*! @file cfe_ts_crc.h
+ * @brief Purpose:
+ *  @details Provide version identifiers for the ELF to cFE Table Converter. @n
+ *  See @ref cfsversions for version and build number and description
+ *
+ */
+
+#ifndef CFE_TS_CRC_VERSION_H
+#define CFE_TS_CRC_VERSION_H
+
+/*
+ * Development Build Macro Definitions
+ */
+#define CFE_TS_CRC_BUILD_NUMBER 8 /*!< @brief Number of commits since baseline */
+#define CFE_TS_CRC_BUILD_BASELINE \
+    "v1.1.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
+
+/*
+ * Version Macro Definitions
+ */
+#define CFE_TS_CRC_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
+#define CFE_TS_CRC_MINOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
+#define CFE_TS_CRC_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
+#define CFE_TS_CRC_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+
+/*
+ * Tools to construct version string
+ */
+#define CFE_TS_CRC_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
+#define CFE_TS_CRC_STR(x) \
+    CFE_TS_CRC_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */
+
+/*! @brief Development Build Version Number.
+ * @details Baseline git tag + Number of commits since baseline. @n
+ * See @ref cfsversions for format differences between development and release versions.
+ */
+#define CFE_TS_CRC_VERSION CFE_TS_CRC_BUILD_BASELINE CFE_TS_CRC_STR(CFE_TS_CRC_BUILD_NUMBER)
+
+/*! @brief Development Build Version String.
+ * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
+ * official version. @n See @ref cfsversions for format differences between development and release versions.
+ */
+#define CFE_TS_CRC_VERSION_STRING                                               \
+    " cFE TS CRC calculator (tblCRCtool) \n"                                    \
+    " DEVELOPMENT BUILD \n"                                                     \
+    " " CFE_TS_CRC_VERSION " \n"                                                \
+    " Last Offical Release: tblCRCtool v3.1.0"     /* For full support please use official release version */
+
+#endif /* CFE_TS_CRC_VERSION_H */


### PR DESCRIPTION
**Describe the contribution**
Close #4 
Close #21 

**Testing performed**
Bundle test - https://github.com/astrogeco/cFS/runs/972139876

**Expected behavior changes**
On execution, tblcrc tool now reports its version when sent the `-help` command
```
# ./cfe_ts_crc -help 
 cFE TS CRC calculator (tblCRCtool) 
 DEVELOPMENT BUILD 
 v1.1.0+dev8 
 Last Offical Release: tblCRCtool v3.1.0

Usage: cfe_ts_crc [filename]

```

**System(s) tested on**
Augmented [GCC Docker Image](https://github.com/docker-library/gcc/blob/36c1ff6d7b44428b35fa8b61787c76b225d8184a/10/Dockerfile)

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz