### PR TITLE
Fix #3, use sizeof() for header sizes.

### DIFF
--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -47,17 +47,17 @@
 
 #include "cfe_ts_crc_version.h"
 
+/* These headers are needed for CFE_FS_Header_t and CFE_TBL_File_Hdr_t, respectively.
+ * This uses the OSAL definition of fixed-width types, even thought this tool
+ * is not using OSAL itself. */
+#include "common_types.h"
+#include "cfe_fs_extern_typedefs.h"
+#include "cfe_tbl_extern_typedefs.h"
+
 #define CFE_ES_CRC_8       1 /**< \brief CRC ( 8 bit additive - returns 32 bit total) (Currently not implemented) */
 #define CFE_ES_CRC_16      2 /**< \brief CRC (16 bit additive - returns 32 bit total) */
 #define CFE_ES_CRC_32      3 /**< \brief CRC (32 bit additive - returns 32 bit total) (Currently not implemented) */
 #define CFE_ES_DEFAULT_CRC CFE_ES_CRC_16 /**< \brief mission specific CRC type  */
-
-typedef unsigned char  uint8;
-typedef unsigned short uint16;
-typedef unsigned int   uint32;
-typedef signed char    int8;
-typedef signed short   int16;
-typedef signed int     int32;
 
 /*
 **             Function Prologue
@@ -142,7 +142,8 @@ int main(int argc, char **argv)
         exit(0);
     }
     /* Set to skip the header (116 bytes) */
-    skipSize = 116;
+    skipSize = sizeof(CFE_FS_Header_t) + sizeof(CFE_TBL_File_Hdr_t);
+
     /* open the input file if possible */
     fd = open(argv[1], O_RDONLY);
     if (fd < 0)


### PR DESCRIPTION
**Describe the contribution**
`sizeof()` will keep this tool in sync if the size of the CFE file or table header should ever change.

Fixes #3 

**Testing performed**
Run the tool and confirm that `skipSize` is unchanged in practice (still 116).

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This does implicitly restrict this tool to the CFE build environment where these headers (common_types.h, cfe_fs_extern_typedefs,h, and cfe_tbl_extern_typedefs.h) are available.  As a result this will no longer be buildable as a fully standalone/external tool.  Based on https://github.com/nasa/tblCRCTool/issues/3#issuecomment-530856962 this is intended/acceptable but I figured it was worth noting again.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.