### PR TITLE
Fix #19, Change full word help option '-help' to '--help'

### DIFF
--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
     char   buffer[100];
 
     /* check for valid input */
-    if ((argc != 2) || (strncmp(argv[1], "-help", 100) == 0))
+    if ((argc != 2) || (strncmp(argv[1], "--help", 100) == 0))
     {
         printf("\ncFE TS CRC calculator for LRO files.");
         printf("\nUsage: cfe_ts_crc [filename]\n");


### PR DESCRIPTION
**Describe the contribution**
Fix #19 

Change the command line argument to '--help' instead of '-help' as per issue #19 

**Testing performed**
Compiled with GCC-9 and clang, no compile errors and behavior remains the same.

**Expected behavior changes**
Only behavior change is the program expects --help instead of -help

**System(s) tested on**
 - Hardware: Macbook Pro 2015
 - OS: Mac OS 10.15.7
- OS: Ubuntu 20.04 (in vm)

**Contributor Info - All information REQUIRED for consideration of pull request**
Todd Martin, personal
