### PR TITLE
tblCRCTool Integration Candidate: 2020-11-24

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This lab application is a ground utility to generate binary table CRCs for cFS. 
 
 ## Version Notes
 
+### Development Build: 1.2.0-rc1+dev3
+
+- Use `sizeof()` instead of a hard coded value for the table file header size to keep this tool in sync if the size of the cFE file or table header should ever change.
+- Update version baseline to v1.2.0-rc1
+- Set REVISION number to 99 to indicate development version
+See <https://github.com/nasa/tblCRCTool/pull/25>
+
 ### Development Build: 1.1.0+dev7
 
 - Create a version header file

--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -47,17 +47,17 @@
 
 #include "cfe_ts_crc_version.h"
 
+/* These headers are needed for CFE_FS_Header_t and CFE_TBL_File_Hdr_t, respectively.
+ * This uses the OSAL definition of fixed-width types, even thought this tool
+ * is not using OSAL itself. */
+#include "common_types.h"
+#include "cfe_fs_extern_typedefs.h"
+#include "cfe_tbl_extern_typedefs.h"
+
 #define CFE_ES_CRC_8       1 /**< \brief CRC ( 8 bit additive - returns 32 bit total) (Currently not implemented) */
 #define CFE_ES_CRC_16      2 /**< \brief CRC (16 bit additive - returns 32 bit total) */
 #define CFE_ES_CRC_32      3 /**< \brief CRC (32 bit additive - returns 32 bit total) (Currently not implemented) */
 #define CFE_ES_DEFAULT_CRC CFE_ES_CRC_16 /**< \brief mission specific CRC type  */
-
-typedef unsigned char  uint8;
-typedef unsigned short uint16;
-typedef unsigned int   uint32;
-typedef signed char    int8;
-typedef signed short   int16;
-typedef signed int     int32;
 
 /*
 **             Function Prologue
@@ -142,7 +142,8 @@ int main(int argc, char **argv)
         exit(0);
     }
     /* Set to skip the header (116 bytes) */
-    skipSize = 116;
+    skipSize = sizeof(CFE_FS_Header_t) + sizeof(CFE_TBL_File_Hdr_t);
+
     /* open the input file if possible */
     fd = open(argv[1], O_RDONLY);
     if (fd < 0)

--- a/cfe_ts_crc_version.h
+++ b/cfe_ts_crc_version.h
@@ -31,7 +31,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_TS_CRC_BUILD_NUMBER 8 /*!< @brief Number of commits since baseline */
+#define CFE_TS_CRC_BUILD_NUMBER 3 /*!< @brief Number of commits since baseline */
 #define CFE_TS_CRC_BUILD_BASELINE \
     "v1.2.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
 

--- a/cfe_ts_crc_version.h
+++ b/cfe_ts_crc_version.h
@@ -33,14 +33,15 @@
  */
 #define CFE_TS_CRC_BUILD_NUMBER 8 /*!< @brief Number of commits since baseline */
 #define CFE_TS_CRC_BUILD_BASELINE \
-    "v1.1.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
+    "v1.2.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
 
 /*
  * Version Macro Definitions
  */
 #define CFE_TS_CRC_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define CFE_TS_CRC_MINOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
-#define CFE_TS_CRC_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
+#define CFE_TS_CRC_REVISION      99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. A value of "99" indicates an unreleased development version.  */
+
 #define CFE_TS_CRC_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
 
 /*


### PR DESCRIPTION
**Describe the contribution**
Fix #3, use sizeof() for header sizes.

HOTFIX, Set REVISION to 99 and update baseline

**Testing performed**
See events for "github actions test" at https://github.com/astrogeco/cFS/actions

**Expected behavior changes**

PR #23 - Use `sizeof()` instead of a hard coded value for the table file header size to keep this tool in sync if the size of the cFE file or table header should ever change. 

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of <https://github.com/nasa/cFS/pull/158>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@jphickey 