### PR TITLE
tblCRCTool Integration candidate: 2021-02-02

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -1,0 +1,55 @@
+name: "CodeQL Analysis"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  SIMULATION: native
+  ENABLE_UNIT_TESTS: true
+  OMIT_DEPRECATED: true
+  BUILDTYPE: release
+
+jobs:
+
+  CodeQL-Build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout bundle
+        uses: actions/checkout@v2
+        with:
+          repository: nasa/cFS
+          submodules: true
+
+      - name: Checkout submodule
+        uses: actions/checkout@v2
+        with:
+          path: tools/tblCRCTool
+
+      - name: Check versions
+        run: git submodule
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+         languages: c
+         queries: +security-extended, security-and-quality
+
+      # Setup the build system
+      - name: Set up for build
+        run: |
+          cp ./cfe/cmake/Makefile.sample Makefile
+          cp -r ./cfe/cmake/sample_defs sample_defs
+          make prep
+
+      # Build the code
+      - name: Build
+        run: make tools/tblCRCTool/
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,53 @@
+name: Format Check
+
+# Run on main push and pull requests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+
+  static-analysis:
+    name: Run format check
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+
+      - name: Install format checker
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic-10 main'
+          sudo apt-get update && sudo apt-get install clang-format-10
+
+      - name: Checkout bundle
+        uses: actions/checkout@v2
+        with:
+          repository: nasa/cFS
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: repo
+
+      - name: Generate format differences
+        run: |
+          cd repo
+          find . -name "*.[ch]" -exec clang-format-10 -i -style=file {} +
+          git diff > $GITHUB_WORKSPACE/style_differences.txt
+
+      - name: Archive Static Analysis Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: style_differences
+          path: style_differences.txt
+
+      - name: Error on differences
+        run: |
+          if [[ -s style_differences.txt ]];
+          then
+            cat style_differences.txt
+            exit -1
+          fi

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,40 @@
+name: Static Analysis
+
+# Run on main push and pull requests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+
+  static-analysis:
+    name: Run cppcheck
+    runs-on: ubuntu-18.04
+    timeout-minutes: 15
+
+    steps:
+
+      - name: Install cppcheck
+        run: sudo apt-get install cppcheck -y
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run general cppcheck
+        run: cppcheck --force --inline-suppr --quiet . 2> cppcheck_err.txt
+
+      - name: Archive Static Analysis Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cppcheck-err
+          path: ./cppcheck_err.txt
+
+      - name: Check for errors
+        run: |
+          if [[ -s cppcheck_err.txt ]];
+          then
+            cat cppcheck_err.txt
+            exit -1
+          fi

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ This lab application is a ground utility to generate binary table CRCs for cFS. 
 
 ## Version Notes
 
+### Development Build: 1.2.0-rc1+dev19
+
+- Changes CLI "help" option to use two dashes: `--help`
+- Adds static analysis and format check to continuous integration workflow. Adds workflow status badges to ReadMe.
+- Adds CodeQL Analysis to continuous integration workflow.
+- See <https://github.com/nasa/tblCRCTool/pull/35>
+
 ### Development Build: 1.2.0-rc1+dev12
 
 - Documentation: Add `Security.md` with instructions on reporting vulnerabilities

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![Static Analysis](https://github.com/nasa/tblCRCTool/workflows/Static%20Analysis/badge.svg)
+![Format Check](https://github.com/nasa/tblCRCTool/workflows/Format%20Check/badge.svg)
+
 # Core Flight System : Framework : Tool : Table CRC Generator
 
 This repository contains NASA's Table CRC Generator Tool (tblCRCTool), which is a framework component of the Core Flight System.
@@ -6,7 +9,7 @@ This lab application is a ground utility to generate binary table CRCs for cFS. 
 
 ## Version Notes
 
-### Development Build: 1.2.0-rc1+dev9
+### Development Build: 1.2.0-rc1+dev12
 
 - Documentation: Add `Security.md` with instructions on reporting vulnerabilities
 - Removes unimplemented CRC cases to eliminate static analysis warnings

--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@ This lab application is a ground utility to generate binary table CRCs for cFS. 
 
 ## Version Notes
 
+### Development Build: 1.2.0-rc1+dev9
+
+- Documentation: Add `Security.md` with instructions on reporting vulnerabilities
+- Removes unimplemented CRC cases to eliminate static analysis warnings
+- See <https://github.com/nasa/tblCRCTool/pull/29>
+
 ### Development Build: 1.2.0-rc1+dev3
 
 - Use `sizeof()` instead of a hard coded value for the table file header size to keep this tool in sync if the size of the cFE file or table header should ever change.
 - Update version baseline to v1.2.0-rc1
 - Set REVISION number to 99 to indicate development version
-See <https://github.com/nasa/tblCRCTool/pull/25>
+- See <https://github.com/nasa/tblCRCTool/pull/25>
 
 ### Development Build: 1.1.0+dev7
 

--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -98,7 +98,6 @@ uint32 CalculateCRC(void *DataPtr, uint32 DataLength, uint32 InputCRC)
     }
 
     return (Crc);
-
 }
 
 int main(int argc, char **argv)

--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -16,29 +16,25 @@
 **      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
-**
-**  lro_ts_crc
-**
-**  This program calculates the CRC of a given file using the same
-**  algorithm as the LRO spacecraft cFE Table Services flight software uses.
-**
-**  Inputs: One string containing the filename of the file to CRC.
-**
-**
-**  Outputs: Prints to the terminal the filename, size, and CRC.
-**           Returns the CRC.
-**
-**  Author: Mike Blau, GSFC Code 582
-**
-**  Date: 1/28/08
-**
-**  Modified 4/24/08  MDB  Added option to skip a specified number of header bytes
-**  Modified 2/04/09  BDT  Modified to compute cFE table services CS
-**  Modified 4/01/09  STS  Modified to always skip header (116 bytes)
-**  Modified 4/01/09  STS  Removed option to skip a specified number of header bytes
-**  Modified 6/15/12  WFM  Replaced the CRC Table with the table used in
-**                         CFE_ES_CalculateCRC
 */
+
+/*
+ *  This program calculates the CRC-16/ARC of a given table file.
+ *
+ *  Algorithm:
+ *    - Name: CRC-16/ARC
+ *    - Polynomial: 0x8005
+ *    - Initialization: 0x0000
+ *    - Reflect Input/Output: true
+ *    - XorOut: 0x0000
+ *
+ *  Inputs: One string containing the filename of the table file to CRC.
+ *
+ *  Outputs: Prints to the terminal the filename, size, and CRC.
+ *           Returns the CRC.
+ *
+ *  Author: Mike Blau, GSFC Code 582
+ */
 #include <stdio.h>
 #include <fcntl.h>
 #include <string.h>
@@ -49,7 +45,8 @@
 
 /* These headers are needed for CFE_FS_Header_t and CFE_TBL_File_Hdr_t, respectively.
  * This uses the OSAL definition of fixed-width types, even thought this tool
- * is not using OSAL itself. */
+ * is not using OSAL itself.
+ */
 #include "common_types.h"
 #include "cfe_fs_extern_typedefs.h"
 #include "cfe_tbl_extern_typedefs.h"

--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
     char   buffer[100];
 
     /* check for valid input */
-    if ((argc != 2) || (strncmp(argv[1], "-help", 100) == 0))
+    if ((argc != 2) || (strncmp(argv[1], "--help", 100) == 0))
     {
         printf("%s\n", CFE_TS_CRC_VERSION_STRING);
         printf("\nUsage: cfe_ts_crc [filename]\n");

--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -54,20 +54,15 @@
 #include "cfe_fs_extern_typedefs.h"
 #include "cfe_tbl_extern_typedefs.h"
 
-#define CFE_ES_CRC_8       1 /**< \brief CRC ( 8 bit additive - returns 32 bit total) (Currently not implemented) */
-#define CFE_ES_CRC_16      2 /**< \brief CRC (16 bit additive - returns 32 bit total) */
-#define CFE_ES_CRC_32      3 /**< \brief CRC (32 bit additive - returns 32 bit total) (Currently not implemented) */
-#define CFE_ES_DEFAULT_CRC CFE_ES_CRC_16 /**< \brief mission specific CRC type  */
-
 /*
 **             Function Prologue
 **
-** Function: CFE_ES_CalculateCRC  (taken directly from lro-cfe-4.2.1 delivery - 2/4/09)
+** Function: CalculateCRC  (originated from lro-cfe-4.2.1 delivery - 2/4/09)
 **
 ** Purpose:  Perform a CRC calculation on a range of memory.
 **
 */
-uint32 CFE_ES_CalculateCRC(void *DataPtr, uint32 DataLength, uint32 InputCRC, uint32 TypeCRC)
+uint32 CalculateCRC(void *DataPtr, uint32 DataLength, uint32 InputCRC)
 {
     int32  i;
     int16  Index;
@@ -96,33 +91,18 @@ uint32 CFE_ES_CalculateCRC(void *DataPtr, uint32 DataLength, uint32 InputCRC, ui
         0x4C80, 0x8C41, 0x4400, 0x84C1, 0x8581, 0x4540, 0x8701, 0x47C0, 0x4680, 0x8641, 0x8201, 0x42C0, 0x4380, 0x8341,
         0x4100, 0x81C1, 0x8081, 0x4040};
 
-    switch (TypeCRC)
+    Crc    = (int16)(0xFFFF & InputCRC);
+    BufPtr = (uint8 *)DataPtr;
+
+    for (i = 0; i < DataLength; i++, BufPtr++)
     {
-            /*       case CFE_ES_CRC_32:                                                    */
-            /*            CFE_ES_WriteToSysLog("CFE ES Calculate CRC32 not Implemented\n"); */
-            /*            break;                                                            */
-
-        case CFE_ES_CRC_16:
-            Crc    = (int16)(0xFFFF & InputCRC);
-            BufPtr = (uint8 *)DataPtr;
-
-            for (i = 0; i < DataLength; i++, BufPtr++)
-            {
-                Index = ((Crc ^ *BufPtr) & 0x00FF);
-                Crc   = ((Crc >> 8) & 0x00FF) ^ CrcTable[Index];
-            }
-            break;
-
-            /*       case CFE_ES_CRC_8:                                                    */
-            /*            CFE_ES_WriteToSysLog("CFE ES Calculate CRC8 not Implemented\n"); */
-            /*            break;                                                           */
-
-        default:
-            break;
+        Index = ((Crc ^ *BufPtr) & 0x00FF);
+        Crc   = ((Crc >> 8) & 0x00FF) ^ CrcTable[Index];
     }
+
     return (Crc);
 
-} /* End of CFE_ES_CalculateCRC() */
+}
 
 int main(int argc, char **argv)
 {
@@ -158,7 +138,7 @@ int main(int argc, char **argv)
     while (done == 0)
     {
         readSize = read(fd, buffer, 100);
-        fileCRC  = CFE_ES_CalculateCRC(buffer, readSize, fileCRC, CFE_ES_CRC_16);
+        fileCRC  = CalculateCRC(buffer, readSize, fileCRC);
         fileSize += readSize;
         if (readSize != 100)
             done = 1;

--- a/cfe_ts_crc_version.h
+++ b/cfe_ts_crc_version.h
@@ -31,7 +31,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_TS_CRC_BUILD_NUMBER 12 /*!< @brief Number of commits since baseline */
+#define CFE_TS_CRC_BUILD_NUMBER 19 /*!< @brief Number of commits since baseline */
 #define CFE_TS_CRC_BUILD_BASELINE \
     "v1.2.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
 
@@ -40,9 +40,11 @@
  */
 #define CFE_TS_CRC_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define CFE_TS_CRC_MINOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
-#define CFE_TS_CRC_REVISION      99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. A value of "99" indicates an unreleased development version.  */
+#define CFE_TS_CRC_REVISION                                                                                           \
+    99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. A value of "99" indicates an unreleased \
+          development version.  */
 
-#define CFE_TS_CRC_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+#define CFE_TS_CRC_MISSION_REV 0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
 
 /*
  * Tools to construct version string
@@ -61,10 +63,10 @@
  * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
  * official version. @n See @ref cfsversions for format differences between development and release versions.
  */
-#define CFE_TS_CRC_VERSION_STRING                                               \
-    " cFE TS CRC calculator (tblCRCtool) \n"                                    \
-    " DEVELOPMENT BUILD \n"                                                     \
-    " " CFE_TS_CRC_VERSION " \n"                                                \
-    " Last Offical Release: tblCRCtool v3.1.0"     /* For full support please use official release version */
+#define CFE_TS_CRC_VERSION_STRING            \
+    " cFE TS CRC calculator (tblCRCtool) \n" \
+    " DEVELOPMENT BUILD \n"                  \
+    " " CFE_TS_CRC_VERSION " \n"             \
+    " Last Offical Release: tblCRCtool v3.1.0" /* For full support please use official release version */
 
 #endif /* CFE_TS_CRC_VERSION_H */

--- a/cfe_ts_crc_version.h
+++ b/cfe_ts_crc_version.h
@@ -31,7 +31,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_TS_CRC_BUILD_NUMBER 9 /*!< @brief Number of commits since baseline */
+#define CFE_TS_CRC_BUILD_NUMBER 12 /*!< @brief Number of commits since baseline */
 #define CFE_TS_CRC_BUILD_BASELINE \
     "v1.2.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
 

--- a/cfe_ts_crc_version.h
+++ b/cfe_ts_crc_version.h
@@ -31,7 +31,7 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_TS_CRC_BUILD_NUMBER 3 /*!< @brief Number of commits since baseline */
+#define CFE_TS_CRC_BUILD_NUMBER 9 /*!< @brief Number of commits since baseline */
 #define CFE_TS_CRC_BUILD_BASELINE \
     "v1.2.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
 


### PR DESCRIPTION
**Describe the contribution**
Fix #19, Changed full word help option '-help' to '--help'
Fix #31, Add static analysis and format check
Fix #33, Add CodeQL analysis to workflow

**Testing performed**
See <https://github.com/nasa/cfs/pull/182/checks>

**Expected behavior changes**
PR #24 - Changes CLI "help" option to use two dashes: `--help`

PR #32 - Adds static analysis and format check to continuous integration workflow. Adds workflow status badges to ReadMe.

PR #34 - Adds CodeQL Analysis to continuous integration workflow. 

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of <https://github.com/nasa/cfs/pull/182/>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@skliper 
@martintc 