### PR TITLE
Fix #50, add printf conversion casts

### DIFF
--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -154,8 +154,8 @@ int main(int argc, char **argv)
 
     /* print the size/CRC results */
     printf("\nTable File Name:            %s\nTable Size:                 %ld Bytes\nExpected TS Validation CRC: "
-           "0x%08X\n\n",
-           argv[1], fileSize, fileCRC);
+           "0x%08lX\n\n",
+           argv[1], (long)fileSize, (unsigned long)fileCRC);
 
     /* Close file and check*/
     if (close(fd) != 0)


### PR DESCRIPTION
**Describe the contribution**
Cast ssize_t to long and uint32 to unsigned long for printf.  This matches the %d and %lX conversions, respectively.

Fixes #50

**Testing performed**
Build tblCRCtool as normal, ensure no errors

**Expected behavior changes**
Should now build successfully if `ssize_t` and `long` are not the same type.

**System(s) tested on**
Ubuntu

**Additional context**
Should be tested with RPI4 toolchain that originally had the error

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
