### PR TITLE
Update build baseline to cFS-Caelum-rc4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This lab application is a ground utility to generate binary table CRCs for cFS. 
 
 ## Version Notes
 
+### Development Build: 1.3.0-rc4+dev2
+
+- Set baseline for cFS-Caelum-rc4: v1.3.0-rc4
+- Update mission rev to use 0xFF for development version
+- See <https://github.com/nasa/cfs/pull/390>
+
 ### Development Build: 1.2.0-rc1+dev33
 
 - Add printf conversion casts to fix Raspberry-Pi4 compilation error

--- a/cfe_ts_crc_version.h
+++ b/cfe_ts_crc_version.h
@@ -31,20 +31,24 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_TS_CRC_BUILD_NUMBER 33 /*!< @brief Number of commits since baseline */
+#define CFE_TS_CRC_BUILD_NUMBER 2 /*!< @brief Number of commits since baseline */
 #define CFE_TS_CRC_BUILD_BASELINE \
-    "v1.2.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
+    "v1.3.0-rc4+dev" /*!< @brief Development Build: git tag that is the base for the current */
 
 /*
  * Version Macro Definitions
  */
 #define CFE_TS_CRC_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define CFE_TS_CRC_MINOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
-#define CFE_TS_CRC_REVISION                                                                                           \
-    99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. A value of "99" indicates an unreleased \
-          development version.  */
+#define CFE_TS_CRC_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision number.      */
 
-#define CFE_TS_CRC_MISSION_REV 0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+/*!
+ * @brief Mission revision.
+ *
+ * Set to 0 on OFFICIAL releases, and set to 255 (0xFF) on development versions.
+ * Values 1-254 are reserved for mission use to denote patches/customizations as needed.
+ */
+#define CFE_TS_CRC_MISSION_REV 0xFF
 
 /*
  * Tools to construct version string


### PR DESCRIPTION
**Describe the contribution**

- Set baseline for cFS-Caelum-rc4: v1.3.0-rc4
- Update mission rev to use 0xFF for development version

**Testing performed**
tblcrcrtool checks <https://github.com/nasa/tblCRCTool/pull/60/checks>
cFS Bundle checks <https://github.com/nasa/cFS/pull/390/checks>

**Expected behavior changes**
Development version number now reports 

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of <https://github.com/nasa/cFS/pull/390>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@astrogeco 