### PR TITLE
Fix #61, Remove explicit filename doxygen comments

### DIFF
--- a/cfe_ts_crc_version.h
+++ b/cfe_ts_crc_version.h
@@ -18,7 +18,7 @@
 **  limitations under the License.
 */
 
-/*! @file cfe_ts_crc.h
+/*! @file
  * @brief Purpose:
  *  @details Provide version identifiers for the ELF to cFE Table Converter. @n
  *  See @ref cfsversions for version and build number and description


### PR DESCRIPTION
**Describe the contribution**
- Fix #61 

**Testing performed**
Make doc, observe no filename warnings

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC