### PR TITLE
Fix #69, Remove unnecessary parentheses around return values.

### DIFF
--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -96,7 +96,7 @@ uint32 CalculateCRC(void *DataPtr, uint32 DataLength, uint32 InputCRC)
         Crc   = ((Crc >> 8) & 0x00FF) ^ CrcTable[Index];
     }
 
-    return (Crc);
+    return Crc;
 }
 
 int main(int argc, char **argv)
@@ -163,5 +163,5 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    return (0);
+    return 0;
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #69 
Removes parentheses in return statements in tblCRCTool that return a single value/term.
This is aligns these return statements with the predominant style of cFS.

**Testing performed**
None, prior to submission of the pull request.

**Expected behavior changes**
No impact on behavior.

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt 