### PR TITLE
Fix #76, Replace exit(1) with preferred macro EXIT_FAILURE

### DIFF
--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
     {
         printf("%s\n", CFE_TS_CRC_VERSION_STRING);
         printf("\nUsage: cfe_ts_crc [filename]\n");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     /* Set to skip the header (116 bytes) */
     skipSize = sizeof(CFE_FS_Header_t) + sizeof(CFE_TBL_File_Hdr_t);
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
     {
         printf("\ncfe_ts_crc error: can't open input file!\n");
         perror(argv[1]);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     /* seek past the number of bytes requested */
     offsetReturn = lseek(fd, skipSize, SEEK_SET);
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
     {
         printf("\ncfe_ts_crc error: lseek failed!\n");
         printf("%s\n", strerror(errno));
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     /* read the input file 100 bytes at a time */
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
         {
             printf("\ncfe_ts_crc error: file read failed!\n");
             printf("%s\n", strerror(errno));
-            exit(1);
+            exit(EXIT_FAILURE);
         }
         fileCRC = CalculateCRC(buffer, readSize, fileCRC);
         fileSize += readSize;
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
     {
         printf("\nerror: Cannot close file!\n");
         printf("%s\n", strerror(errno));
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     return 0;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #76 
`exit(1)` replaced in 5 locations with the equivalent, but more portable and expressive, `EXIT_FAILURE` macro.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to code logic/behavior.

**Contributor Info**
Avi Weiss @thnkslprpt