### PR TITLE
Fix #79, updating tblCRCTool to use new versioning system.

### DIFF
--- a/cfe_ts_crc.c
+++ b/cfe_ts_crc.c
@@ -108,11 +108,16 @@ int main(int argc, char **argv)
     int     fd;
     char    buffer[100];
     off_t   offsetReturn = 0;
+    char    VersionString[CFE_TS_CRC_CFG_MAX_VERSION_STR_LEN];
 
     /* check for valid input */
     if ((argc != 2) || (strncmp(argv[1], "--help", 100) == 0))
     {
-        printf("%s\n", CFE_TS_CRC_VERSION_STRING);
+        snprintf(VersionString, CFE_TS_CRC_CFG_MAX_VERSION_STR_LEN,
+        "%s %s %s (Codename %s), Last Official Release: %s %s)",
+        "tblCRCTool", CFE_TS_CRC_REVISION == 0 ? "Development Build" : "Release",
+        CFE_TS_CRC_VERSION,
+        CFE_TS_CRC_BUILD_CODENAME, "tblCRCTool", CFE_TS_CRC_LAST_OFFICIAL);
         printf("\nUsage: cfe_ts_crc [filename]\n");
         exit(EXIT_FAILURE);
     }

--- a/cfe_ts_crc_version.h
+++ b/cfe_ts_crc_version.h
@@ -29,16 +29,22 @@
 /*
  * Development Build Macro Definitions
  */
-#define CFE_TS_CRC_BUILD_NUMBER 28 /*!< @brief Number of commits since baseline */
-#define CFE_TS_CRC_BUILD_BASELINE \
-    "v1.3.0-rc4+dev" /*!< @brief Development Build: git tag that is the base for the current */
+#define CFE_TS_CRC_BUILD_NUMBER    28 /*!< @brief Number of commits since baseline */
+#define CFE_TS_CRC_BUILD_BASELINE  "equuleus-rc1" /*!< @brief Development Build: git tag that is the base for the current */
+#define CFE_TS_CRC_BUILD_DEV_CYCLE "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define CFE_TS_CRC_BUILD_CODENAME  "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
 #define CFE_TS_CRC_MAJOR_VERSION 1  /*!< @brief Major version number */
 #define CFE_TS_CRC_MINOR_VERSION 1  /*!< @brief Minor version number */
-#define CFE_TS_CRC_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define CFE_TS_CRC_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define CFE_TS_CRC_LAST_OFFICIAL "v3.1.0"
 
 /*!
  * @brief Mission revision.
@@ -62,14 +68,12 @@
  */
 #define CFE_TS_CRC_VERSION CFE_TS_CRC_BUILD_BASELINE CFE_TS_CRC_STR(CFE_TS_CRC_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
- * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Max Version String length.
+ * 
+ * Maximum length that a tblCRCTool version string can be.
+ * 
  */
-#define CFE_TS_CRC_VERSION_STRING            \
-    " cFE TS CRC calculator (tblCRCtool) \n" \
-    " DEVELOPMENT BUILD \n"                  \
-    " " CFE_TS_CRC_VERSION " \n"             \
-    " Last Official Release: tblCRCtool v3.1.0" /* For full support please use official release version */
+#define CFE_TS_CRC_CFG_MAX_VERSION_STR_LEN 256
 
 #endif /* CFE_TS_CRC_VERSION_H */


### PR DESCRIPTION
**Describe the contribution**
Fixes #79.

**Testing performed**
Workflows were run.

**Expected behavior changes**
No behavior changes, however the following changes were made to the versioning system:
1. Build Baseline is set to "equuleus-rc1"
2. Mission Revision is set to to 00
3. "CFE_TS_CRC_BUILD_DEV_CYCLE" macro has been defined
4. Version String has been removed, and all references to it replaced with the Build Baseline/Codename

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC